### PR TITLE
feat(bot): support commands issued via privmsg

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -2,8 +2,10 @@ var irc      = require("irc");
 var _        = require("lodash");
 var storage  = require('./storage');
 var config   = require('./../config');
+var reply    = require('./reply');
 
 var bot = new irc.Client(config.server, config.irc.userName, config.irc);
+module.exports = bot;
 
 /**
  * Spin up connection to channel and load plugins
@@ -36,13 +38,13 @@ function load(channel, callback){
  * @param channel {string} Channel command was said in
  * @param message {string} Message sent by user
  */
-function doCommand(from, channel, message) {
+function doCommand(from, channel, message, r) {
 	var params = message.split(' ');
   var message = channel.commands[params[0].substr(1)];
   var tokens = params.slice(1).join('+');
   message = message.replace(/(\:tokens)/ig, tokens);
   message = message.replace(/(\:nick)/ig, from);
-  channel.say(message);
+  r.reply(message);
 }
 
 /**
@@ -51,14 +53,14 @@ function doCommand(from, channel, message) {
  * @param channel {Object} Channel command was said in
  * @param message {string} Message sent by user
  */
-function doPattern(from, channel, message) {
+function doPattern(from, channel, message, reply) {
 	// @FIXME Not super performant?
   var patterns = channel ? channel.patterns : {}, result = false;
   _.each(channel.patterns, function(callback, pattern) {
     expression = new RegExp(pattern, 'i');
     var matches = expression.exec(message);
     if (matches) {
-      result = callback(from, matches);
+      result = callback(from, matches, reply);
     }
   });
   return result;
@@ -159,27 +161,48 @@ bot.addListener("pm", function(from, message) {
     manage[params[0]](from, params);
   } else {
     var p = parsePM(message);
+    var r = reply(from, p.channel, true);
     if (p) {
       if (p.channel && p.channel.commands[p.cmd]) {
-        doCommand(from, p.channel, p.cmdmsg);
+        doCommand(from, p.channel, p.cmdmsg, r);
       } else {
-        doPattern(from, p.channel, p.cmdmsg);
+        doPattern(from, p.channel, p.cmdmsg, r);
       }
     }
   }
 });
 
+var MSG_COMMANDS = [{
+  // !cmd ...
+  re: /^(!(\S+))(\s+(.+)?)?$/,
+  fn: function(re, str) {
+    var matches = re.exec(str);
+    return matches && { cmd: matches[2], text: matches[4] };
+  }
+}];
+
+function parseMSG(str) {
+  var parsed, i;
+  for (i=0; i<MSG_COMMANDS.length; ++i) {
+    var parser = MSG_COMMANDS[i];
+    if ((parsed = parser.fn(parser.re, str))) {
+      parsed.cmdmsg = ['!' + parsed.cmd, parsed.text].join(" ");
+      return parsed;
+    }
+  }
+  return false;
+}
+
 bot.addListener("message#", function(from, channel, message) {
-	channel = storage.channels[channel];
-	var params = message.split(' ');
-  if (
-  	params[0].length > 1
-  	&& params[0][0] === '!'
-  	&& channel.commands[params[0].substr(1)]
-  ) {
-  	doCommand(from, channel, message);
-  } else {
-    doPattern(from, channel, message);
+  var p = parseMSG(message);
+  if (p) {
+  	p.channel = storage.channels[channel];
+    var r = reply(from, p.channel);
+    if (p.channel.commands[p.cmd]) {
+    	doCommand(from, p.channel, message, r);
+    } else {
+      doPattern(from, p.channel, message, r);
+    }
   }
 });
 

--- a/lib/plugins/core.js
+++ b/lib/plugins/core.js
@@ -3,27 +3,27 @@ var config    = require('./../../config');
 
 var core = function(channel){
   return {
-    "!remember (\\S+) is (.+)": function(from, matches) {
+    "!remember (\\S+) is (.+)": function(from, matches, r) {
       channel.commands[matches[1]] = matches[2];
       storage.update(channel, function(err){
         if (err) {
-          channel.say('Error saving "'+matches[1]+'": '+err, from);
+          r.reply('Error saving "'+matches[1]+'": '+err, from);
           if (config.owner)
-            channel.say('Please notify '+config.owner, from);
+            r.reply('Please notify '+config.owner, from);
         } else {
-          channel.say('Command "'+matches[1]+'" saved!', from);
+          r.reply('Command "'+matches[1]+'" saved!', from);
         }
       });
     },
-    "!forget (\\S+)": function(from, matches) {
+    "!forget (\\S+)": function(from, matches, r) {
       delete channel.commands[matches[1]];
       storage.update(channel, function(err){
         if (err) {
-          channel.say('Error removing "'+matches[1]+'": '+err, from);
+          r.reply('Error removing "'+matches[1]+'": '+err, from);
           if (config.owner)
-            channel.say('Please notify '+config.owner, from);
+            r.reply('Please notify '+config.owner, from);
         } else {
-          channel.say('Command "'+matches[1]+'" forgotten!', from);
+          r.reply('Command "'+matches[1]+'" forgotten!', from);
         }
       });
     }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -1,0 +1,63 @@
+var storage = require('./storage'),
+    _       = require("lodash");
+
+function Reply(user, channel, isPM) {
+  this.user = user;
+  this.channel = channel;
+  this.isPM = isPM;
+  this.bot = require('./bot');
+}
+
+/**
+ * Send message in PM if responding to a privmsg, or to channel if responding to a channel
+ * message.
+ * @param message {string} Message to send
+ * @param [recipient] {string} (Optional) Person to send message to
+ */
+Reply.prototype.reply = function(message, recipient) {
+  if (this.isPM) {
+    this.bot.say(this.user, message);
+  } else if (this.channel) {
+    this.channel.say(message, recipient);
+  }
+};
+
+/**
+ * Send message to channel if and only if a channel is available.
+ * @param message {string} Message to send
+ * @param [recipient] {string} (Optional) Person to send message to
+ */
+Reply.prototype.toChannel = function(message, recipient) {
+  if (this.channel) {
+    if (recipient && message.indexOf(recipient) === -1) {
+      message = recipient + ": " + message;
+    }
+    this.channel.say(message);
+  }
+}
+
+/**
+ * Send message to user, even if responding to a channel message.
+ * @param message {string} Message to send
+ */
+Reply.prototype.toUser = function(message) {
+  this.bot.say(this.user, message);
+}
+
+module.exports = function(from, channel, isPM) {
+  if (typeof isPM === 'object') {
+    bot = isPM;
+    isPM = false;
+  }
+  if (channel) {
+    // Ensure channel is registered
+    if (_.isString(channel) && _.isObject(storage.channels[channel])) {
+      channel = storage.channels[channel];
+    } else if (_.isObject(channel) && channel === storage.channels[channel.name]) {
+      // NOOP
+    } else {
+      channel = undefined;
+    }
+  }
+  return new Reply(from, channel, isPM);
+}


### PR DESCRIPTION
PM performs special parsing of commands by testing `!CMD for #CHAN command
message`. This enables channel-specific commands to be registered via
privmsg.

---

_edit_ now supports alternative proposed `#channel !cmd msg` syntax

---

_edit_ now sends replies to the appropriate place

Closes #20
